### PR TITLE
Handle nested micro-interaction timers cleanup

### DIFF
--- a/src/components/anime/MicroInteractionOrchestrator.tsx
+++ b/src/components/anime/MicroInteractionOrchestrator.tsx
@@ -79,9 +79,13 @@ export const MicroInteractionOrchestrator: React.FC<MicroInteractionProps> = ({
         });
 
         // Remove interaction after its duration
-        setTimeout(() => {
+        const rmTimeout = setTimeout(() => {
           setActiveInteractions(prev => prev.filter(i => i.id !== interaction.id));
         }, interaction.duration);
+
+        // Nested timers won't be cleared by the outer timeout, so track them
+        // to ensure they don't fire after unmount or re-render
+        timeouts.push(rmTimeout);
       }, interaction.delay);
 
       timeouts.push(timeout);
@@ -97,6 +101,7 @@ export const MicroInteractionOrchestrator: React.FC<MicroInteractionProps> = ({
     timeouts.push(completeTimeout);
 
     return () => {
+      // Cancel any pending timeouts including nested removal timers
       timeouts.forEach(clearTimeout);
       setActiveInteractions([]);
     };


### PR DESCRIPTION
## Summary
- track nested removal timers in `MicroInteractionOrchestrator`
- ensure cleanup cancels both scheduled and nested timeouts
- document need for explicit cleanup of nested timers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 32 problems (16 errors, 16 warnings))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4136567b0832d9cf53474866d9460