### PR TITLE
refactor: manage carousel transition timers

### DIFF
--- a/src/components/anime/AnimatedHeroCarousel.tsx
+++ b/src/components/anime/AnimatedHeroCarousel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '../ui/button';
@@ -38,6 +38,16 @@ export const AnimatedHeroCarousel: React.FC = () => {
   const [userInteracted, setUserInteracted] = useState(false);
   const { isSeriousMode } = useSeriousMode();
 
+  const transitionStartTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const transitionEndTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (transitionStartTimer.current) clearTimeout(transitionStartTimer.current);
+      if (transitionEndTimer.current) clearTimeout(transitionEndTimer.current);
+    };
+  }, []);
+
   // Auto-advance slides based on their duration
   useEffect(() => {
     if (isPaused || isSeriousMode || isTransitioning) return;
@@ -76,10 +86,20 @@ export const AnimatedHeroCarousel: React.FC = () => {
   const handleSlideTransition = (targetIndex: number) => {
     if (targetIndex !== currentSlide && !isTransitioning) {
       setIsTransitioning(true);
+
+      if (transitionStartTimer.current) {
+        clearTimeout(transitionStartTimer.current);
+        transitionStartTimer.current = null;
+      }
+      if (transitionEndTimer.current) {
+        clearTimeout(transitionEndTimer.current);
+        transitionEndTimer.current = null;
+      }
+
       // Brief delay before changing slide to show transition effect
-      setTimeout(() => {
+      transitionStartTimer.current = setTimeout(() => {
         setCurrentSlide(targetIndex);
-        setTimeout(() => setIsTransitioning(false), 600);
+        transitionEndTimer.current = setTimeout(() => setIsTransitioning(false), 600);
       }, 300);
     }
   };


### PR DESCRIPTION
## Summary
- keep slide transition timers in refs
- clear timers on unmount to avoid leaks
- reset timers when starting a new transition

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: found 16 errors, 16 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a41704f57c832d963e365d24acbfb5