### PR TITLE
Generate overlay random positions on client

### DIFF
--- a/src/components/anime/RippleTransition.tsx
+++ b/src/components/anime/RippleTransition.tsx
@@ -24,6 +24,7 @@ export const RippleTransition = ({
   const { isSeriousMode } = useSeriousMode();
   const [ripples, setRipples] = useState<Array<{ id: number; x: number; y: number }>>([]);
   const [rippleId, setRippleId] = useState(0);
+  const [random, setRandom] = useState<(() => number) | null>(null);
 
   const sizeValues = {
     sm: { initial: 0, animate: 100 },
@@ -32,13 +33,23 @@ export const RippleTransition = ({
   };
 
   useEffect(() => {
-    if (trigger && !isSeriousMode) {
+    if (typeof window !== 'undefined') {
+      let seed = 42;
+      setRandom(() => () => {
+        const x = Math.sin(seed++) * 10000;
+        return x - Math.floor(x);
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (trigger && !isSeriousMode && random) {
       // Create multiple ripples at random positions
       const rippleCount = compact ? 2 : 3;
       const newRipples = Array.from({ length: rippleCount }, (_, i) => ({
         id: rippleId + i,
-        x: Math.random() * 100,
-        y: Math.random() * 100
+        x: random() * 100,
+        y: random() * 100
       }));
       
       setRipples(prev => [...prev, ...newRipples]);
@@ -53,7 +64,7 @@ export const RippleTransition = ({
 
       return () => clearTimeout(timer);
     }
-  }, [trigger, isSeriousMode, rippleId, onComplete, compact]);
+  }, [trigger, isSeriousMode, rippleId, onComplete, compact, random]);
 
   if (isSeriousMode) {
     return <div className={className}>{children}</div>;


### PR DESCRIPTION
## Summary
- move random position generation for SqueegeEffectOverlay into client-side state with seeded RNG
- seed RippleTransition random generator and guard it to run only in browser

## Testing
- `npm run lint` *(fails: Unexpected any, hooks errors, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a419636b2c832da1613e97c3674803