### PR TITLE
Fix micro-interaction rendering in HeroSlide

### DIFF
--- a/src/components/anime/HeroSlide.tsx
+++ b/src/components/anime/HeroSlide.tsx
@@ -32,7 +32,6 @@ export const HeroSlide: React.FC<HeroSlideProps> = ({ data }) => {
   const { isSeriousMode } = useSeriousMode();
   const { t } = useTranslation();
   const [storyActive, setStoryActive] = useState(false);
-  const [interactionPhase, setInteractionPhase] = useState(0);
   const [manualTriggerKey, setManualTriggerKey] = useState(0);
 
   useEffect(() => {
@@ -44,7 +43,6 @@ export const HeroSlide: React.FC<HeroSlideProps> = ({ data }) => {
     return () => {
       clearTimeout(timer);
       setStoryActive(false);
-      setInteractionPhase(0);
     };
   }, [data.service]);
 
@@ -81,8 +79,6 @@ export const HeroSlide: React.FC<HeroSlideProps> = ({ data }) => {
   ];
 
   const renderMicroInteraction = () => {
-    if (isSeriousMode) return null;
-    
     switch (data.animationType) {
       case 'squeegee':
         return (
@@ -332,7 +328,6 @@ export const HeroSlide: React.FC<HeroSlideProps> = ({ data }) => {
               <MicroInteractionOrchestrator
                 serviceType={data.service}
                 isActive={storyActive}
-                onComplete={() => setInteractionPhase(prev => prev + 1)}
                 manualTriggerKey={manualTriggerKey}
               />
               


### PR DESCRIPTION
## Summary
- remove unused `interactionPhase` state from HeroSlide
- ensure serious mode renders traditional micro-interactions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 16 errors, 16 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a4195e07a8832db9e64ea4d70ba7dc