### PR TITLE
fix: remove duplicate declarations in animation components

### DIFF
--- a/src/components/anime/BuildyMascot.tsx
+++ b/src/components/anime/BuildyMascot.tsx
@@ -202,30 +202,3 @@ export const WalkingBuildyMascot = (props: Omit<BuildyMascotProps, 'animation'>)
 export const CleaningBuildyMascot = (props: Omit<BuildyMascotProps, 'animation'>) => (
   <BuildyMascot {...props} animation="clean" />
 );
-
-// Hook for mascot animations
-export const useBuildyMascot = () => {
-  const [animation, setAnimation] = useState<BuildyMascotProps['animation']>('idle');
-  const [isPlaying, setIsPlaying] = useState(true);
-
-  const play = (newAnimation?: BuildyMascotProps['animation']) => {
-    if (newAnimation) setAnimation(newAnimation);
-    setIsPlaying(true);
-  };
-
-  const pause = () => setIsPlaying(false);
-  
-  const reset = () => {
-    setAnimation('idle');
-    setIsPlaying(true);
-  };
-
-  return {
-    animation,
-    isPlaying,
-    play,
-    pause,
-    reset,
-    setAnimation
-  };
-};

--- a/src/components/anime/LottieAnimation.tsx
+++ b/src/components/anime/LottieAnimation.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
-import Lottie from 'lottie-react';
+import Lottie, { LottieRefCurrentProps } from 'lottie-react';
 import { useSeriousMode } from '@/contexts/SeriousModeContext';
 import { SafeImage } from '@/components/ui/safe-image';
 
@@ -60,10 +60,9 @@ export const LottieAnimation = ({
   const [isPlaying, setIsPlaying] = useState(autoplay);
   const [isInView, setIsInView] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const lottieRef = useRef<any>(null);
+  const lottieRef = useRef<LottieRefCurrentProps>(null);
   const loadedRef = useRef(false);
   const watchdogRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
-  const lottieRef = useRef<unknown>(null);
 
   // Size classes
   const sizeClasses = {
@@ -85,13 +84,6 @@ export const LottieAnimation = ({
       try {
         const data = await getAnimation(animationPath);
         if (cancelled) return;
-        
-        if (!ok) {
-          console.warn('Lottie assets failed to load, using static fallback:', animationPath);
-          setUseFallback(true);
-          setAnimationData(null);
-          return;
-        }
         if (import.meta.env.DEV) {
           console.debug('Lottie loaded:', animationPath);
         }

--- a/src/components/anime/SqueegeEffectOverlay.tsx
+++ b/src/components/anime/SqueegeEffectOverlay.tsx
@@ -41,23 +41,6 @@ export const SqueegeEffectOverlay = ({
   }, []);
 
   const wipeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Precompute random positions to avoid hydration mismatches
-  const dropletPositions = useMemo(
-    () =>
-      Array.from({ length: 8 }, () => ({
-        x: Math.random() * 100,
-        y: Math.random() * 30
-      })),
-    []
-  );
-  const sparklePositions = useMemo(
-    () =>
-      Array.from({ length: 8 }, () => ({
-        left: Math.random() * 100,
-        top: Math.random() * 100
-      })),
-    []
-  );
 
 
   useEffect(() => {

--- a/src/components/anime/StoryDirector.tsx
+++ b/src/components/anime/StoryDirector.tsx
@@ -152,25 +152,14 @@ export const StoryDirector: React.FC<StoryDirectorProps> = ({
         setStartTime(Date.now());
       }
       if (!isStoryActive) {
-        setIsStoryActive(true);
-        console.debug('[StoryDirector] Story started', { beatId: beat.id });
-      }
-    },
-    [isStoryActive, startTime]
-  );
-
-  const triggerBeat = (beat: StoryBeat) => {
-    setCurrentBeat(beat);
-    if (!startTime) {
-      setStartTime(Date.now());
-    }
-    if (!isStoryActive) {
       setIsStoryActive(true);
       if (import.meta.env.DEV) {
         console.debug('[StoryDirector] Story started', { beatId: beat.id });
       }
-    }
-  };
+      }
+    },
+    [isStoryActive, startTime]
+  );
 
 
   const setStoryActive = useCallback((active: boolean) => {


### PR DESCRIPTION
## Summary
- fix lottie animation ref type and remove stray variable redeclaration
- drop extra droplet/sparkle definitions from SqueegeEffectOverlay
- remove duplicate triggerBeat logic in StoryDirector and unused mascot hook

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 10 errors, 16 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a41cc04824832d8c382c108a8d21e2