### PR TITLE
feat: swap emoji micro‑interactions for images

### DIFF
--- a/src/components/anime/HeroSlide.tsx
+++ b/src/components/anime/HeroSlide.tsx
@@ -34,6 +34,7 @@ export const HeroSlide: React.FC<HeroSlideProps> = ({ data }) => {
   const [storyActive, setStoryActive] = useState(false);
   const [manualTriggerKey, setManualTriggerKey] = useState(0);
   const introTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastClickRef = useRef(0);
 
   useEffect(() => {
     // Start story sequence when slide mounts
@@ -344,7 +345,15 @@ export const HeroSlide: React.FC<HeroSlideProps> = ({ data }) => {
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.8, delay: 0.4 }}
           >
-            <div className="relative w-full max-w-md aspect-square" onClick={() => setManualTriggerKey((k) => k + 1)}>
+            <div
+              className="relative w-full max-w-md aspect-square"
+              onClick={() => {
+                const now = Date.now();
+                if (now - lastClickRef.current < 700) return;
+                lastClickRef.current = now;
+                setManualTriggerKey((k) => k + 1);
+              }}
+            >
               <LottieAnimation
                 animationPath={data.animationPath}
                 fallbackImage={data.fallbackImage}


### PR DESCRIPTION
## Summary
- replace emoji renders with SafeImage-based assets and cap concurrent micro-interactions
- throttle hero manual triggers to prevent rapid stacking

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 11 errors, 16 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a42cdb5658832d892b8aae8395db72