### PR TITLE
refactor: remove hero emojis and stabilize micro interactions

### DIFF
--- a/src/components/anime/AnimatedHeroCarousel.tsx
+++ b/src/components/anime/AnimatedHeroCarousel.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Briefcase } from 'lucide-react';
 import { Button } from '../ui/button';
 import { HeroSlide, type HeroSlideData } from './HeroSlide';
 import { useSeriousMode } from '@/contexts/SeriousModeContext';
@@ -230,12 +230,12 @@ export const AnimatedHeroCarousel: React.FC = () => {
           </div>
           {isSeriousMode && (
             <motion.div
-              className="bg-muted/90 backdrop-blur-sm rounded-full px-3 py-1 text-xs font-medium text-muted-foreground border"
+              className="bg-muted/90 backdrop-blur-sm rounded-full px-3 py-1 text-xs font-medium text-muted-foreground border flex items-center gap-1"
               initial={{ opacity: 0, scale: 0.8 }}
               animate={{ opacity: 1, scale: 1 }}
               transition={{ duration: 0.3 }}
             >
-              💼 Professional Mode
+              <Briefcase className="h-3 w-3" /> Professional Mode
             </motion.div>
           )}
         </div>

--- a/src/components/anime/HeroSlide.tsx
+++ b/src/components/anime/HeroSlide.tsx
@@ -8,6 +8,7 @@ import { useSeriousMode } from '@/contexts/SeriousModeContext';
 import { useTranslation } from 'react-i18next';
 import { StoryDirector, useStory } from './StoryDirector';
 import { MicroInteractionOrchestrator } from './MicroInteractionOrchestrator';
+import { SafeImage } from '@/components/ui/safe-image';
 
 export interface HeroSlideData {
   service: 'pool' | 'pest' | 'deepClean';
@@ -35,6 +36,9 @@ export const HeroSlide: React.FC<HeroSlideProps> = ({ data }) => {
   const [manualTriggerKey, setManualTriggerKey] = useState(0);
   const introTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastClickRef = useRef(0);
+
+  const resolveAsset = (path: string) =>
+    `${import.meta.env.BASE_URL.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
 
   useEffect(() => {
     // Start story sequence when slide mounts
@@ -124,23 +128,23 @@ export const HeroSlide: React.FC<HeroSlideProps> = ({ data }) => {
             />
             {/* Animated pest retreat */}
             <motion.div
-              className="absolute text-2xl"
+              className="absolute w-8 h-8"
               style={{ left: '80%', top: '20%' }}
               initial={{ x: 0, rotate: 0, scale: 1 }}
               animate={{ x: -100, rotate: 45, scale: 0.7 }}
               transition={{ delay: 3.0, duration: 2.0, ease: "easeOut" }}
             >
-              🐛💨
+              <SafeImage src={resolveAsset('/anime/pests/pest-retreat-01.png')} alt="pest" className="w-8 h-8" />
             </motion.div>
             {/* White flag surrender */}
             <motion.div
-              className="absolute text-xl"
+              className="absolute w-6 h-6"
               style={{ left: '70%', top: '30%' }}
               initial={{ opacity: 0, scale: 0 }}
               animate={{ opacity: 1, scale: 1 }}
               transition={{ delay: 4.0, duration: 0.5 }}
             >
-              🏳️
+              <SafeImage src={resolveAsset('/anime/pests/pest-white-flag.png')} alt="flag" className="w-6 h-6" />
             </motion.div>
             {/* Mission accomplished badge */}
             <motion.div
@@ -162,10 +166,10 @@ export const HeroSlide: React.FC<HeroSlideProps> = ({ data }) => {
             {getSparklePositions().map((pos, i) => (
               <motion.div
                 key={i}
-                className="absolute text-2xl will-change-transform"
+                className="absolute will-change-transform w-5 h-5"
                 style={{ left: `${pos.x}%`, top: `${pos.y}%` }}
                 initial={{ scale: 0, rotate: 0, opacity: 0 }}
-                animate={{ 
+                animate={{
                   scale: [0, 1.2, 0],
                   rotate: [0, 180, 360],
                   opacity: [0, 1, 0]
@@ -176,7 +180,7 @@ export const HeroSlide: React.FC<HeroSlideProps> = ({ data }) => {
                   ease: "easeOut"
                 }}
               >
-                ✨
+                <SafeImage src={resolveAsset('/anime/effects/droplet-hop-01.png')} alt="sparkle" className="w-5 h-5" />
               </motion.div>
             ))}
             {/* Bubble effects */}

--- a/src/components/anime/MicroInteractionOrchestrator.tsx
+++ b/src/components/anime/MicroInteractionOrchestrator.tsx
@@ -31,10 +31,17 @@ export const MicroInteractionOrchestrator: React.FC<MicroInteractionProps> = ({
   const [activeInteractions, setActiveInteractions] = useState<InteractionBeat[]>([]);
   const timeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const manualTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const MAX_CONCURRENT = 6;
+  const lastManualRef = useRef(0);
+  const MAX_CONCURRENT = 4;
 
   const resolveAsset = (path: string) =>
     `${import.meta.env.BASE_URL.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+
+  useEffect(() => {
+    if (import.meta.env.DEV) {
+      console.info('[Orchestrator] Emoji-free overlay enabled');
+    }
+  }, []);
 
   const addInteraction = (interaction: InteractionBeat, manual = false) => {
     setActiveInteractions(prev => {
@@ -53,23 +60,23 @@ export const MicroInteractionOrchestrator: React.FC<MicroInteractionProps> = ({
         return [
           { id: 'pool-start', delay: 500, duration: 2000, type: 'squeegee', message: 'Starting pool cleaning...', position: { x: 30, y: 70 } },
           { id: 'pool-clean', delay: 2500, duration: 1500, type: 'sparkle-burst', message: 'Crystal clear water!', position: { x: 70, y: 30 } },
-          { id: 'pool-complete', delay: 4000, duration: 1000, type: 'celebration', message: 'Pool perfection achieved! 🏊‍♂️', position: { x: 50, y: 50 } }
+          { id: 'pool-complete', delay: 4000, duration: 1000, type: 'celebration', message: 'Pool perfection achieved!', position: { x: 50, y: 50 } }
         ];
       
       case 'pest':
         return [
           { id: 'pest-detect', delay: 300, duration: 1000, type: 'pest-retreat', message: 'Pests detected!', position: { x: 80, y: 20 } },
           { id: 'pest-spray', delay: 1300, duration: 2000, type: 'pest-retreat', message: 'Safe treatment applied...', position: { x: 60, y: 40 } },
-          { id: 'pest-retreat', delay: 3300, duration: 1500, type: 'pest-retreat', message: 'Pests retreating! 🏃‍♂️', position: { x: 20, y: 70 } },
-          { id: 'pest-victory', delay: 4800, duration: 1000, type: 'celebration', message: 'Mission accomplished! 🛡️', position: { x: 50, y: 50 } }
+          { id: 'pest-retreat', delay: 3300, duration: 1500, type: 'pest-retreat', message: 'Pests retreating!', position: { x: 20, y: 70 } },
+          { id: 'pest-victory', delay: 4800, duration: 1000, type: 'celebration', message: 'Mission accomplished!', position: { x: 50, y: 50 } }
         ];
       
       case 'deepClean':
         return [
           { id: 'clean-assess', delay: 400, duration: 1000, type: 'sparkle-burst', message: 'Assessing surfaces...', position: { x: 25, y: 25 } },
           { id: 'clean-scrub', delay: 1400, duration: 2500, type: 'squeegee', message: 'Deep cleaning in progress...', position: { x: 50, y: 60 } },
-          { id: 'clean-sparkle', delay: 3900, duration: 2000, type: 'sparkle-burst', message: 'Surfaces sparkling! ✨', position: { x: 75, y: 25 } },
-          { id: 'clean-done', delay: 5900, duration: 1000, type: 'celebration', message: 'Spotless perfection! 🌟', position: { x: 50, y: 50 } }
+          { id: 'clean-sparkle', delay: 3900, duration: 2000, type: 'sparkle-burst', message: 'Surfaces sparkling!', position: { x: 75, y: 25 } },
+          { id: 'clean-done', delay: 5900, duration: 1000, type: 'celebration', message: 'Spotless perfection!', position: { x: 50, y: 50 } }
         ];
       
       default:
@@ -136,6 +143,8 @@ export const MicroInteractionOrchestrator: React.FC<MicroInteractionProps> = ({
   useEffect(() => {
     if (!manualTriggerKey || isSeriousMode) return;
     const now = Date.now();
+    if (now - lastManualRef.current < 800) return;
+    lastManualRef.current = now;
     const extra: InteractionBeat = serviceType === 'pest'
       ? { id: `manual-pest-${now}`, delay: 0, duration: 1500, type: 'pest-retreat', message: 'Pests retreat!', position: { x: 60, y: 30 } }
       : { id: `manual-sparkle-${now}`, delay: 0, duration: 1300, type: 'sparkle-burst', message: 'Extra sparkle!', position: { x: 55, y: 45 } };

--- a/src/components/anime/NarrativeBridge.tsx
+++ b/src/components/anime/NarrativeBridge.tsx
@@ -44,7 +44,7 @@ export const NarrativeBridge: React.FC<NarrativeBridgeProps> = ({
             onAnimationComplete={() => scheduleComplete(600)}
           >
             <div className="text-2xl font-bold text-white drop-shadow-lg">
-              From Pool to Pest Protection! 🏊‍♂️➡️🐛
+              From Pool to Pest Protection!
             </div>
           </motion.div>
         );
@@ -60,7 +60,7 @@ export const NarrativeBridge: React.FC<NarrativeBridgeProps> = ({
             onAnimationComplete={() => scheduleComplete(600)}
           >
             <div className="text-2xl font-bold text-white drop-shadow-lg">
-              Now for Deep Cleaning! 🐛➡️✨
+              Now for Deep Cleaning!
             </div>
           </motion.div>
         );
@@ -80,7 +80,7 @@ export const NarrativeBridge: React.FC<NarrativeBridgeProps> = ({
               className="absolute inset-0 z-20 flex items-center justify-center bg-gradient-to-r from-green-500/20 to-blue-500/20"
             >
               <div className="text-2xl font-bold text-white drop-shadow-lg">
-                Back to Pool Perfection! ✨➡️🏊‍♂️
+                Back to Pool Perfection!
               </div>
             </motion.div>
           </RippleTransition>

--- a/src/components/anime/SeriousModeToggle.tsx
+++ b/src/components/anime/SeriousModeToggle.tsx
@@ -53,8 +53,9 @@ export const SeriousModeToggle = () => {
           </Button>
         </TooltipTrigger>
         <TooltipContent side="bottom" className="bg-card border shadow-lg">
-          <p className="text-sm font-medium">
-            {isSeriousMode ? '🌸 Switch to Kawaii Mode' : '💼 Switch to Professional Mode'}
+          <p className="text-sm font-medium flex items-center gap-1">
+            {isSeriousMode ? <Heart className="h-4 w-4" /> : <Briefcase className="h-4 w-4" />}
+            {isSeriousMode ? 'Switch to Kawaii Mode' : 'Switch to Professional Mode'}
           </p>
           <p className="text-xs text-muted-foreground mt-1">
             {isSeriousMode ? 'Enable cute animations & mascots' : 'Disable animations for business'}

--- a/src/components/anime/SqueegeEffectOverlay.tsx
+++ b/src/components/anime/SqueegeEffectOverlay.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useSeriousMode } from '@/contexts/SeriousModeContext';
+import { SafeImage } from '@/components/ui/safe-image';
 
 interface SqueegeEffectOverlayProps {
   children: React.ReactNode;
@@ -22,6 +23,9 @@ export const SqueegeEffectOverlay = ({
 
   const [dropletPositions, setDropletPositions] = useState<Array<{ x: number; y: number }>>([]);
   const [sparklePositions, setSparklePositions] = useState<Array<{ left: number; top: number }>>([]);
+
+  const resolveAsset = (path: string) =>
+    `${import.meta.env.BASE_URL.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
 
   const createSeededRandom = (seed = 42) => {
     return () => {
@@ -160,7 +164,7 @@ export const SqueegeEffectOverlay = ({
             {sparklePositions.map(({ left, top }, i) => (
               <motion.div
                 key={`sparkle-${i}`}
-                className="absolute text-yellow-400 text-xl"
+                className="absolute w-5 h-5"
                 style={{
                   left: left + '%',
                   top: top + '%'
@@ -176,7 +180,7 @@ export const SqueegeEffectOverlay = ({
                   ease: "easeOut"
                 }}
               >
-                ✨
+                <SafeImage src={resolveAsset('/anime/effects/droplet-hop-01.png')} alt="sparkle" className="w-5 h-5" />
               </motion.div>
             ))}
           </div>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -52,7 +52,7 @@ const resources = {
             benefit1: 'Professional deep cleaning',
             benefit2: 'Chemical balancing and testing',
             benefit3: 'Equipment maintenance and repairs',
-            badge: 'Pool Perfected! 🏊‍♂️'
+            badge: 'Pool Perfected!'
           },
           pest: {
             title: 'Gentle Pest Solutions That Work',
@@ -61,7 +61,7 @@ const resources = {
             storyCaption: 'See how we make pests retreat while keeping your family safe',
             benefits: ['Family-safe treatments', 'Pet-friendly', 'Follow-up visits', 'Warranty included'],
             primaryCta: 'Book Free Pest Inspection',
-            badge: 'Mission Accomplished! 🛡️',
+            badge: 'Mission Accomplished!',
             benefit1: 'Family-safe treatment methods',
             benefit2: '24/7 pest monitoring',
             benefit3: '100% satisfaction guarantee'
@@ -73,7 +73,7 @@ const resources = {
             storyCaption: 'Experience the magical transformation of deep cleaning excellence',
             benefits: ['Eco-friendly products', 'Post-clean inspection', 'Satisfaction guarantee', 'Room-by-room care'],
             primaryCta: 'Book Free Cleaning Quote',
-            badge: 'Spotless Perfection! 🌟',
+            badge: 'Spotless Perfection!',
             benefit1: 'Professional grade equipment',
             benefit2: 'Eco-friendly cleaning products',
             benefit3: 'Detailed cleaning checklist'
@@ -157,7 +157,7 @@ const resources = {
             benefit1: 'تنظيف عميق احترافي',
             benefit2: 'توازن المواد الكيميائية والاختبار',
             benefit3: 'صيانة وإصلاح المعدات',
-            badge: 'مسبح مثالي! 🏊‍♂️'
+            badge: 'مسبح مثالي!'
           },
           pest: {
             title: 'حلول لطيفة ضد الآفات تعمل بفعالية',
@@ -166,7 +166,7 @@ const resources = {
             storyCaption: 'شاهد كيف نجعل الآفات تتراجع مع الحفاظ على سلامة عائلتك',
             benefits: ['علاجات آمنة للعائلة', 'صديقة للحيوانات الأليفة', 'زيارات متابعة', 'ضمان مشمول'],
             primaryCta: 'احجز فحص آفات مجاني',
-            badge: 'تمت المهمة! 🛡️',
+            badge: 'تمت المهمة!',
             benefit1: 'طرق علاج آمنة للعائلة',
             benefit2: 'مراقبة الآفات على مدار الساعة',
             benefit3: 'ضمان الرضا 100%'
@@ -178,7 +178,7 @@ const resources = {
             storyCaption: 'اختبر التحول السحري لتميز التنظيف العميق',
             benefits: ['منتجات صديقة للبيئة', 'فحص ما بعد التنظيف', 'ضمان الرضا', 'العناية غرفة بغرفة'],
             primaryCta: 'احجز عرض تنظيف مجاني',
-            badge: 'مثالية بلا عيوب! 🌟',
+            badge: 'مثالية بلا عيوب!',
             benefit1: 'معدات احترافية',
             benefit2: 'منتجات تنظيف صديقة للبيئة',
             benefit3: 'قائمة تنظيف مفصلة'


### PR DESCRIPTION
## Summary
- replace hero/banner emojis with SafeImage icons or plain text
- throttle manual micro-interaction triggers and lower concurrent limit
- drop emoji badges from i18n translations

## Testing
- `npm run lint` (fails: Empty block statement, Unexpected any, require() forbidden)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a430c28024832d9bf585b61759bd11