### PR TITLE
Fix base URL issues causing broken images

### DIFF
--- a/src/components/anime/BuildyMascot.tsx
+++ b/src/components/anime/BuildyMascot.tsx
@@ -2,6 +2,11 @@ import { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import Lottie from 'lottie-react';
 
+// Ensure asset paths respect the configured base URL so images don't
+// break when the site is deployed in a subdirectory.
+const resolveAsset = (path: string) =>
+  `${import.meta.env.BASE_URL.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+
 interface BuildyMascotProps {
   animation?: 'idle' | 'walk' | 'clean' | 'spray' | 'squeegee';
   size?: 'sm' | 'md' | 'lg' | 'xl';
@@ -37,22 +42,22 @@ export const BuildyMascot = ({
   }, []);
 
   // Animation frame sequences
-  const frameSequences = {
-    idle: [
-      '/anime/mascots/buildy-idle-wave-01.png',
-      '/anime/mascots/buildy-idle-wave-02.png'
-    ],
-    walk: [
-      '/anime/mascots/buildy-walk-01.png', 
-      '/anime/mascots/buildy-walk-02.png'
-    ],
-    clean: [
-      '/anime/mascots/buildy-sparkle-clean-01.png',
-      '/anime/mascots/buildy-sparkle-clean-02.png'
-    ],
-    spray: ['/anime/mascots/buildy-sprayer-01.png'],
-    squeegee: ['/anime/mascots/buildy-squeegee-01.png']
-  };
+    const frameSequences = {
+      idle: [
+        resolveAsset('/anime/mascots/buildy-idle-wave-01.png'),
+        resolveAsset('/anime/mascots/buildy-idle-wave-02.png')
+      ],
+      walk: [
+        resolveAsset('/anime/mascots/buildy-walk-01.png'),
+        resolveAsset('/anime/mascots/buildy-walk-02.png')
+      ],
+      clean: [
+        resolveAsset('/anime/mascots/buildy-sparkle-clean-01.png'),
+        resolveAsset('/anime/mascots/buildy-sparkle-clean-02.png')
+      ],
+      spray: [resolveAsset('/anime/mascots/buildy-sprayer-01.png')],
+      squeegee: [resolveAsset('/anime/mascots/buildy-squeegee-01.png')]
+    };
 
   // Size classes
   const sizeClasses = {
@@ -114,16 +119,16 @@ export const BuildyMascot = ({
 
   // Lottie animation data (simplified - would be imported from JSON files)
   const lottieAnimations = {
-    idle: '/anime/lottie/buildy-idle-wave.json',
-    walk: '/anime/lottie/buildy-walk.json', // Would need to be created
-    clean: '/anime/lottie/buildy-clean.json' // Would need to be created
-  };
+      idle: resolveAsset('/anime/lottie/buildy-idle-wave.json'),
+      walk: resolveAsset('/anime/lottie/buildy-walk.json'), // Would need to be created
+      clean: resolveAsset('/anime/lottie/buildy-clean.json') // Would need to be created
+    };
 
   // Static fallback for reduced motion
   if (prefersReducedMotion) {
     return (
       <img
-        src="/anime/static/buildy-static.png"
+        src={resolveAsset('/anime/static/buildy-static.png')}
         alt="BuildCare mascot Buildy"
         className={`${sizeClasses[size]} object-contain ${className}`}
       />

--- a/src/components/anime/LottieAnimation.tsx
+++ b/src/components/anime/LottieAnimation.tsx
@@ -4,6 +4,11 @@ import Lottie, { LottieRefCurrentProps } from 'lottie-react';
 import { useSeriousMode } from '@/contexts/SeriousModeContext';
 import { SafeImage } from '@/components/ui/safe-image';
 
+// Resolve asset paths respecting Vite's base URL. This prevents broken
+// references when the app is served from a subdirectory.
+const resolveAsset = (path: string) =>
+  `${import.meta.env.BASE_URL.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+
 interface LottieAnimationProps {
   animationPath: string;
   fallbackImage?: string;
@@ -74,6 +79,10 @@ export const LottieAnimation = ({
   };
 
   const maxSizeStyle = maxSize ? { maxWidth: `${maxSize}px`, maxHeight: `${maxSize}px` } : {};
+
+  const resolvedFallback = resolveAsset(
+    fallbackImage || '/anime/static/buildy-static.png'
+  );
 
   // Load Lottie animation data using dynamic import
   useEffect(() => {
@@ -163,9 +172,9 @@ export const LottieAnimation = ({
         animate={{ opacity: 1, scale: 1 }}
         transition={{ duration: 0.5 }}
       >
-        <SafeImage 
-          src={fallbackImage || '/anime/static/buildy-static.png'} 
-          alt="Service illustration" 
+        <SafeImage
+          src={resolvedFallback}
+          alt="Service illustration"
           className="w-full h-full object-contain"
         />
       </motion.div>
@@ -174,14 +183,14 @@ export const LottieAnimation = ({
 
   if (useFallback || !animationData) {
     return (
-      <motion.div 
+      <motion.div
         className={`${sizeClasses[size]} ${className} flex items-center justify-center`}
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.3 }}
       >
-        <SafeImage 
-          src={fallbackImage || '/anime/static/buildy-static.png'}
+        <SafeImage
+          src={resolvedFallback}
           alt="Service illustration"
           className="w-full h-full object-contain"
         />
@@ -266,7 +275,7 @@ export const preloadLottieAssets = async (animationPath: string, fallbackImage?:
     // Preload fallback image
     if (fallbackImage) {
       const img = new Image();
-      img.src = fallbackImage;
+      img.src = resolveAsset(fallbackImage);
     }
   } catch (error) {
     console.warn('Preload failed for:', animationPath, error);


### PR DESCRIPTION
## Summary
- Resolve image paths relative to Vite base URL in Lottie and mascot components
- Preload fallback assets using base-aware URLs to avoid broken images

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 11 errors, 16 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a439b35af0832d82ffb875cb9524f4