### PR TITLE
fix: resolve broken images with safe fallback

### DIFF
--- a/src/components/CharacterShowcase.tsx
+++ b/src/components/CharacterShowcase.tsx
@@ -1,4 +1,5 @@
 import { Card } from "@/components/ui/card";
+import { SafeImage } from "@/components/ui/safe-image";
 import cureRatsImage from "@/assets/cure-rats.png";
 import sadRoachImage from "@/assets/sad-roach.png";
 
@@ -8,8 +9,8 @@ export const CharacterShowcase = () => {
       <Card className="mascot-card border-2 border-secondary/30 hover:border-secondary/50">
         <div className="p-6 text-center">
           <div className="relative mb-6">
-            <img 
-              src={cureRatsImage} 
+            <SafeImage
+              src={cureRatsImage}
               alt="Cure Rats Team"
               className="w-full max-w-sm mx-auto object-contain rounded-mascot"
             />
@@ -43,8 +44,8 @@ export const CharacterShowcase = () => {
       <Card className="mascot-card border-2 border-destructive/30 hover:border-destructive/50">
         <div className="p-6 text-center">
           <div className="relative mb-6">
-            <img 
-              src={sadRoachImage} 
+            <SafeImage
+              src={sadRoachImage}
               alt="Sad Roach Character"
               className="w-32 h-32 mx-auto object-contain animate-wiggle"
             />

--- a/src/components/MascotCard.tsx
+++ b/src/components/MascotCard.tsx
@@ -1,5 +1,6 @@
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { SafeImage } from "@/components/ui/safe-image";
 
 interface MascotCardProps {
   title: string;
@@ -21,8 +22,8 @@ export const MascotCard = ({ title, description, image, variant, features }: Mas
     <Card className={`mascot-card border-2 ${variantClasses[variant]} transition-all duration-300 hover:shadow-xl`}>
       <div className="p-6 text-center">
         <div className="relative mb-6">
-          <img 
-            src={image} 
+          <SafeImage
+            src={image}
             alt={title}
             className="w-32 h-32 mx-auto object-contain animate-float"
           />

--- a/src/components/ui/safe-image.tsx
+++ b/src/components/ui/safe-image.tsx
@@ -1,8 +1,18 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 
 export interface SafeImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   fallbackSrc?: string;
 }
+
+// Resolve asset paths respecting Vite's base URL. This prevents broken
+// references when the app is served from a subdirectory.
+const resolveAsset = (path: string | undefined) => {
+  if (!path) return undefined;
+  if (/^(https?:|data:)/.test(path)) return path;
+  const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+  if (path.startsWith(base)) return path;
+  return `${base}/${path.replace(/^\//, '')}`;
+};
 
 export const SafeImage: React.FC<SafeImageProps> = ({
   src,
@@ -13,26 +23,30 @@ export const SafeImage: React.FC<SafeImageProps> = ({
   onError,
   ...rest
 }) => {
-  const [currentSrc, setCurrentSrc] = useState<string | undefined>(src as string | undefined);
+  const resolvedSrc = resolveAsset(src as string | undefined);
+  const resolvedFallback = resolveAsset(fallbackSrc);
+  const [currentSrc, setCurrentSrc] = useState<string | undefined>(resolvedSrc);
   const [hasFailed, setHasFailed] = useState(false);
 
   // Debug logging for image loading
-  React.useEffect(() => {
-    if (src) {
-      console.log('SafeImage attempting to load:', src);
+  useEffect(() => {
+    if (resolvedSrc) {
+      console.log('SafeImage attempting to load:', resolvedSrc);
     }
-  }, [src]);
+    setCurrentSrc(resolvedSrc);
+    setHasFailed(false);
+  }, [resolvedSrc]);
 
   const handleError = useCallback<React.ReactEventHandler<HTMLImageElement>>(
     (e) => {
       if (!hasFailed) {
         setHasFailed(true);
-        setCurrentSrc(fallbackSrc);
-        console.error('SafeImage failed to load:', src, '→ falling back to:', fallbackSrc);
+        setCurrentSrc(resolvedFallback);
+        console.error('SafeImage failed to load:', src, '→ falling back to:', resolvedFallback);
       }
       onError?.(e);
     },
-    [fallbackSrc, hasFailed, onError, src]
+    [resolvedFallback, hasFailed, onError, src]
   );
 
   return (
@@ -40,7 +54,7 @@ export const SafeImage: React.FC<SafeImageProps> = ({
       src={currentSrc}
       alt={alt || 'Image'}
       loading={loading}
-      decoding={decoding as any}
+      decoding={decoding}
       onError={handleError}
       {...rest}
     />

--- a/src/pages/services/Pool.tsx
+++ b/src/pages/services/Pool.tsx
@@ -11,6 +11,7 @@ import { SqueegeEffectOverlay } from '@/components/anime/SqueegeEffectOverlay';
 import { PoolRippleTransition } from '@/components/anime/RippleTransition';
 import { ScrollTriggeredAnimation } from '@/components/anime/ScrollTriggeredAnimation';
 import { BuildyMascot } from '@/components/anime/BuildyMascot';
+import { SafeImage } from '@/components/ui/safe-image';
 import { useSeriousMode } from '@/contexts/SeriousModeContext';
 import buildyPoolImage from '@/assets/buildy-pool.png';
 
@@ -205,9 +206,9 @@ const Pool = () => {
                   
                   {/* Trust Badges */}
                   <div className="flex items-center gap-4">
-                    <img src="/anime/badges/uae-certified.png" alt="UAE Certified" className="w-10 h-10" />
-                    <img src="/anime/badges/family-safe.png" alt="Family Safe" className="w-10 h-10" />
-                    <img src="/anime/badges/24-7-service.png" alt="24/7 Service" className="w-10 h-10" />
+                    <SafeImage src="/anime/badges/uae-certified.png" alt="UAE Certified" className="w-10 h-10" />
+                    <SafeImage src="/anime/badges/family-safe.png" alt="Family Safe" className="w-10 h-10" />
+                    <SafeImage src="/anime/badges/24-7-service.png" alt="24/7 Service" className="w-10 h-10" />
                   </div>
                 </motion.div>
 
@@ -413,9 +414,9 @@ const Pool = () => {
                   <div className="grid grid-cols-2 h-48">
                     <div className="relative">
                       <div className="absolute inset-0 bg-gradient-to-r from-red-500/20 to-transparent z-10" />
-                      <img 
-                        src="/anime/illustrations/pool-service-scene.png" 
-                        alt="Before" 
+                      <SafeImage
+                        src="/anime/illustrations/pool-service-scene.png"
+                        alt="Before"
                         className="w-full h-full object-cover opacity-60"
                       />
                       <div className="absolute top-2 left-2 bg-red-500 text-white px-2 py-1 rounded text-xs font-semibold">
@@ -424,9 +425,9 @@ const Pool = () => {
                     </div>
                     <div className="relative">
                       <div className="absolute inset-0 bg-gradient-to-l from-green-500/20 to-transparent z-10" />
-                      <img 
-                        src="/anime/illustrations/pool-service-scene.png" 
-                        alt="After" 
+                      <SafeImage
+                        src="/anime/illustrations/pool-service-scene.png"
+                        alt="After"
                         className="w-full h-full object-cover"
                       />
                       <div className="absolute top-2 right-2 bg-green-500 text-white px-2 py-1 rounded text-xs font-semibold">


### PR DESCRIPTION
## Summary
- make SafeImage aware of base URL and provide robust fallback
- render mascot and badge images via SafeImage to prevent broken links

## Testing
- `npm run build`
- `npm run lint` *(fails: Empty block statement; Unexpected any; A `require()` style import is forbidden)*
- `npx eslint src/components/ui/safe-image.tsx src/pages/services/Pool.tsx src/components/MascotCard.tsx src/components/CharacterShowcase.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a43bfc1730832db98eb8d5b296aa0a